### PR TITLE
Allow writes to use transparent retries

### DIFF
--- a/src/main/java/com/couchbase/spark/japi/CouchbaseDocumentRDD.java
+++ b/src/main/java/com/couchbase/spark/japi/CouchbaseDocumentRDD.java
@@ -24,6 +24,7 @@ package com.couchbase.spark.japi;
 import com.couchbase.client.java.document.Document;
 import com.couchbase.spark.DocumentRDDFunctions;
 import com.couchbase.spark.StoreMode;
+import com.couchbase.spark.connection.RetryOptions;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.rdd.RDD;
 import scala.reflect.ClassTag;
@@ -58,7 +59,11 @@ public class CouchbaseDocumentRDD<T extends Document<?>> extends JavaRDD<T> {
     }
 
     public void saveToCouchbase(StoreMode storeMode, String bucket) {
-        new DocumentRDDFunctions<T>(source.rdd()).saveToCouchbase(bucket, storeMode);
+        saveToCouchbase(storeMode, bucket, null);
+    }
+
+    public void saveToCouchbase(StoreMode storeMode, String bucket, RetryOptions retryOptions) {
+        new DocumentRDDFunctions<T>(source.rdd()).saveToCouchbase(bucket, storeMode, retryOptions);
     }
 
     @Override

--- a/src/main/scala/com/couchbase/spark/DocumentRDDFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/DocumentRDDFunctions.scala
@@ -1,55 +1,68 @@
 /**
- * Copyright (C) 2015 Couchbase, Inc.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
- * IN THE SOFTWARE.
- */
+  * Copyright (C) 2015 Couchbase, Inc.
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to deal
+  * in the Software without restriction, including without limitation the rights
+  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  * copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in
+  * all copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALING
+  * IN THE SOFTWARE.
+  */
 package com.couchbase.spark
 
+import java.util.concurrent.TimeUnit
+
+import com.couchbase.client.core.BackpressureException
+import com.couchbase.client.core.time.Delay
 import com.couchbase.client.java.document.Document
-import com.couchbase.spark.connection.{CouchbaseConfig, CouchbaseConnection}
+import com.couchbase.client.java.error.{CouchbaseOutOfMemoryException, TemporaryFailureException}
+import com.couchbase.client.java.util.retry.RetryBuilder
+import com.couchbase.spark.connection.{CouchbaseConfig, CouchbaseConnection, RetryOptions}
 import com.couchbase.spark.internal.OnceIterable
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
-import rx.lang.scala.Observable
 import rx.lang.scala.JavaConversions._
+import rx.lang.scala.Observable
 
 class DocumentRDDFunctions[D <: Document[_]](rdd: RDD[D])
   extends Serializable
-  with Logging {
+    with Logging {
 
   private val cbConfig = CouchbaseConfig(rdd.context.getConf)
 
-  def saveToCouchbase(bucketName: String = null, storeMode: StoreMode = StoreMode.UPSERT): Unit = {
+  def saveToCouchbase(bucketName: String = null,
+                      storeMode: StoreMode = StoreMode.UPSERT,
+                      retryOptions: RetryOptions = null): Unit = {
     rdd.foreachPartition(iter => {
       if (iter.nonEmpty) {
         val bucket = CouchbaseConnection().bucket(cbConfig, bucketName).async()
         Observable
           .from(OnceIterable(iter))
-          .flatMap(doc =>  {
+          .flatMap(doc => {
             storeMode match {
-              case StoreMode.UPSERT => toScalaObservable(bucket.upsert[D](doc))
-              case StoreMode.INSERT_AND_FAIL => toScalaObservable(bucket.insert[D](doc))
-              case StoreMode.REPLACE_AND_FAIL => toScalaObservable(bucket.replace[D](doc))
-              case StoreMode.INSERT_AND_IGNORE => toScalaObservable(bucket.insert[D](doc))
+              case StoreMode.UPSERT =>
+                toScalaObservable(withRetry(bucket.upsert[D](doc), retryOptions))
+              case StoreMode.INSERT_AND_FAIL =>
+                toScalaObservable(withRetry(bucket.insert[D](doc), retryOptions))
+              case StoreMode.REPLACE_AND_FAIL =>
+                toScalaObservable(withRetry(bucket.replace[D](doc),retryOptions))
+              case StoreMode.INSERT_AND_IGNORE =>
+                toScalaObservable(withRetry(bucket.insert[D](doc), retryOptions))
                 .doOnError(err => logWarning("Insert failed, but suppressed.", err))
                 .onErrorResumeNext(throwable => Observable.empty)
-              case StoreMode.REPLACE_AND_IGNORE => toScalaObservable(bucket.replace[D](doc))
+              case StoreMode.REPLACE_AND_IGNORE =>
+                toScalaObservable(withRetry(bucket.replace[D](doc), retryOptions))
                 .doOnError(err => logWarning("Replace failed, but suppressed.", err))
                 .onErrorResumeNext(throwable => Observable.empty)
             }
@@ -60,4 +73,16 @@ class DocumentRDDFunctions[D <: Document[_]](rdd: RDD[D])
     })
   }
 
+  def withRetry(observable: Observable[D], retryOptions: RetryOptions): Observable[D] = {
+    retryOptions match {
+      case null => observable
+      case _ => observable.retryWhen(
+        RetryBuilder
+          .anyOf(classOf[TemporaryFailureException], classOf[BackpressureException],
+            classOf[CouchbaseOutOfMemoryException])
+          .delay(Delay.exponential(TimeUnit.MILLISECONDS, retryOptions.maxDelay, retryOptions.minDelay))
+          .max(retryOptions.maxTries)
+          .build())
+    }
+  }
 }

--- a/src/main/scala/com/couchbase/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/couchbase/spark/sql/DefaultSource.scala
@@ -21,12 +21,14 @@
  */
 package com.couchbase.spark.sql
 
-import com.couchbase.client.java.document.{JsonDocument}
+import com.couchbase.client.java.document.JsonDocument
 import com.couchbase.client.java.document.json.JsonObject
-import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
-import org.apache.spark.sql.sources.{CreatableRelationProvider, SchemaRelationProvider, BaseRelation, RelationProvider}
-import org.apache.spark.sql.types.StructType
 import com.couchbase.spark._
+import com.couchbase.spark.connection.{RetryOptions, CouchbaseConfig}
+import org.apache.spark.Logging
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider, SchemaRelationProvider}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 
 /**
  * The default couchbase source for Spark SQL.
@@ -72,6 +74,15 @@ class DefaultSource
     val bucketName = parameters.get("bucket").orNull
     val idFieldName = parameters.getOrElse("idField", DefaultSource.DEFAULT_DOCUMENT_ID_FIELD)
 
+    val cbConfig = CouchbaseConfig(data.sqlContext.sparkContext.getConf)
+
+    val useRetry = parameters.getOrElse("useRetry", "false").toBoolean
+    val maxRetries = if (parameters.contains("maxRetries")) parameters("maxRetries").toInt else cbConfig.retryOpts.maxTries
+    val maxRetryDelay = if (parameters.contains("maxRetryDelay")) parameters("maxRetryDelay").toInt else cbConfig.retryOpts.maxDelay
+    val minRetryDelay = if (parameters.contains("minRetryDelay")) parameters("minRetryDelay").toInt else cbConfig.retryOpts.minDelay
+    val retryOptions = if (useRetry) RetryOptions(maxRetries, maxRetryDelay, minRetryDelay) else null
+
+
     val storeMode = mode match {
       case SaveMode.Append =>
         throw new UnsupportedOperationException("SaveMode.Append is not supported with Couchbase.")
@@ -88,7 +99,7 @@ class DefaultSource
         encoded.removeKey(idFieldName)
         JsonDocument.create(id, encoded)
       })
-      .saveToCouchbase(bucketName, storeMode)
+      .saveToCouchbase(bucketName, storeMode, retryOptions)
 
     createRelation(sqlContext, parameters, data.schema)
   }


### PR DESCRIPTION
The fix for SPARKC-36 addressed transparent retries for reads but not for writes.   When saving a DataFrame you can enable retries by setting useRetry to true and then rely on the values set in the SparkConf or override them via property map passed through the couchbase method.