### PR TITLE
Added support for composable filter expressions and nested attribute names

### DIFF
--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -155,15 +155,30 @@ object N1QLRelation {
    */
   def filterToExpression(filter: Filter): String = {
     filter match {
-      case EqualTo(attr, value) => s" `$attr` = '$value'"
-      case GreaterThan(attr, value) => s" `$attr` > $value"
-      case GreaterThanOrEqual(attr, value) => s" `$attr` >= $value"
-      case LessThan(attr, value) => s" `$attr` < $value"
-      case LessThanOrEqual(attr, value) => s" `$attr` <= $value"
-      case IsNull(attr) => s" `$attr` IS NULL"
-      case IsNotNull(attr) => s" `$attr` IS NOT NULL"
+      case EqualTo(attr, value) => s" ${filterAttribute(attr)} = '$value'"
+      case GreaterThan(attr, value) => s" ${filterAttribute(attr)} > $value"
+      case GreaterThanOrEqual(attr, value) => s" ${filterAttribute(attr)} >= $value"
+      case LessThan(attr, value) => s" ${filterAttribute(attr)} < $value"
+      case LessThanOrEqual(attr, value) => s" ${filterAttribute(attr)} <= $value"
+      case IsNull(attr) => s" ${filterAttribute(attr)} IS NULL"
+      case IsNotNull(attr) => s" ${filterAttribute(attr)} IS NOT NULL"
+      case And(leftFilter, rightFilter) =>
+        s" (${filterToExpression(leftFilter)} AND ${filterToExpression(rightFilter)})"
+      case Or(leftFilter, rightFilter) =>
+        s" (${filterToExpression(leftFilter)} OR ${filterToExpression(rightFilter)})"
       case _ => throw new Exception("Unsupported filter")
     }
+  }
+
+  private def filterAttribute(attr: String): String ={
+    attr match {
+      case r"(.*)${first}\.(.*)${second}" => s"`$first`.`$second`"
+      case _ => s"`$attr`"
+    }
+  }
+
+  implicit class Regex(sc: StringContext) {
+    def r = new util.matching.Regex(sc.parts.mkString, sc.parts.tail.map(_ => "x"): _*)
   }
 
 }

--- a/src/test/scala/com/couchbase/spark/sql/N1QLRelationSpec.scala
+++ b/src/test/scala/com/couchbase/spark/sql/N1QLRelationSpec.scala
@@ -1,0 +1,35 @@
+package com.couchbase.spark.sql
+
+import org.apache.spark.sql.sources.{And, EqualTo, LessThan}
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
+
+/**
+  * Created by luca on 30/05/16.
+  */
+class N1QLRelationSpec extends FlatSpec with Matchers {
+
+  "N1QLRelation" should "parse paths in nested filter attributes" in {
+    val filter = EqualTo("flavour.type", "10")
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" `flavour`.`type` = '10'")
+  }
+
+  "N1QLRelation" should "not parse paths in nested filter attributes" in {
+    val filter = EqualTo("type", "10")
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" `type` = '10'")
+  }
+
+  "N1QLRelation" should "parse complex filter attributes" in {
+    val filter = And(EqualTo("type", "10"),LessThan("flavour.origin", 4))
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" ( `type` = '10' AND  `flavour`.`origin` < 4)")
+  }
+}


### PR DESCRIPTION
This PR adds support for:
- And/Or(s).
- nested attributes. Prior to this patch, adding a filter on 'myjsonroot.fieldname' would generate the following filter: WHERE `myjsonroot.fieldname` ... , instead of WHERE `myjsonroot`.`fieldname`