### PR TITLE
deeply nested attributes are now properly parsed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "spark-connector"
 
 organization := "com.couchbase.client"
 
-version := "1.2.0"
+version := "1.2.1-SNAPSHOT"
 
 description := "Official Couchbase Spark Connector"
 
@@ -18,8 +18,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "1.6.1" % "provided",
   "org.apache.spark" %% "spark-streaming" % "1.6.1" % "provided",
   "org.apache.spark" %% "spark-sql" % "1.6.1" % "provided",
-  "com.couchbase.client" % "java-client" % "2.2.7",
-  "io.reactivex" %% "rxscala" % "0.25.1",
+  "com.couchbase.client" % "java-client" % "2.3.0",
+  "io.reactivex" %% "rxscala" % "0.26.1",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   "junit" % "junit" % "4.12" % "test"
 )

--- a/src/main/scala/com/couchbase/spark/PairRDDFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/PairRDDFunctions.scala
@@ -19,9 +19,4 @@ import org.apache.spark.rdd.RDD
 
 class PairRDDFunctions[V](rdd: RDD[(String, V)]) {
 
-//  def toCouchbaseDocument[D <: Document[_] : ClassTag]
-//    (implicit converter: DocumentConverter[D, V]): DocumentRDDFunctions[D] = {
-//    rdd.map(kv => converter.convert(kv._1, kv._2))
-//  }
-
 }

--- a/src/main/scala/com/couchbase/spark/RDDFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/RDDFunctions.scala
@@ -16,7 +16,7 @@
 package com.couchbase.spark
 
 import com.couchbase.client.java.view.{SpatialViewQuery, ViewQuery}
-import com.couchbase.spark.internal.{OnceIterable}
+import com.couchbase.spark.internal.OnceIterable
 import com.couchbase.spark.rdd._
 
 import scala.reflect.ClassTag
@@ -31,11 +31,6 @@ class RDDFunctions[T](rdd: RDD[T]) extends Serializable {
 
   /**
    * Convert a RDD[String] to a RDD[D]. It's available if T is String.
-   *
-   * @param ct
-   * @param evidence
-   * @tparam D
-   * @return
    */
   def couchbaseGet[D <: Document[_]](bucketName: String = null)
     (implicit ct: ClassTag[D], evidence: RDD[T] <:< RDD[String]): RDD[D] = {

--- a/src/main/scala/com/couchbase/spark/connection/SubdocLookupAccessor.scala
+++ b/src/main/scala/com/couchbase/spark/connection/SubdocLookupAccessor.scala
@@ -26,6 +26,8 @@ import rx.lang.scala.JavaConversions._
 import rx.lang.scala.Observable
 
 import scala.collection.mutable
+import scala.collection.JavaConverters._
+
 
 case class SubdocLookupSpec(id: String, get: Seq[String], exists: Seq[String])
 
@@ -50,8 +52,8 @@ class SubdocLookupAccessor(cbConfig: CouchbaseConfig, specs: Seq[SubdocLookupSpe
         .from(specs)
         .flatMap(spec => {
             var builder = bucket.lookupIn(spec.id)
-            spec.exists.foreach(builder.exists)
-            spec.get.foreach(builder.get)
+            builder.exists(spec.exists: _*)
+            builder.get(spec.get: _*)
 
             toScalaObservable(builder.execute()).map(fragment => {
               val content = mutable.Map[String, Any]()

--- a/src/main/scala/com/couchbase/spark/rdd/KeyValueRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/KeyValueRDD.scala
@@ -76,7 +76,7 @@ class KeyValueRDD[D <: Document[_]]
           rv.toInt & numPartitions - 1
         }).map(grouped => {
           val hostname = Some(
-            bucketConfig.nodeAtIndex(bucketConfig.nodeIndexForMaster(grouped._1)).hostname()
+            bucketConfig.nodeAtIndex(bucketConfig.nodeIndexForMaster(grouped._1, false)).hostname()
           )
           val currentIdx = partitionIndex
           partitionIndex += 1

--- a/src/main/scala/com/couchbase/spark/rdd/KeyValueRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/KeyValueRDD.scala
@@ -19,8 +19,7 @@ package com.couchbase.spark.rdd
 import java.net.InetAddress
 import java.util.zip.CRC32
 
-import com.couchbase.client.core.CouchbaseException
-import com.couchbase.client.core.config.{CouchbaseBucketConfig, BucketType}
+import com.couchbase.client.core.config.CouchbaseBucketConfig
 import com.couchbase.client.core.message.cluster.{GetClusterConfigRequest, GetClusterConfigResponse}
 import com.couchbase.client.java.document.Document
 import com.couchbase.spark.connection.{CouchbaseConnection, KeyValueAccessor, CouchbaseConfig}

--- a/src/main/scala/com/couchbase/spark/rdd/QueryRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/QueryRDD.scala
@@ -15,19 +15,11 @@
  */
 package com.couchbase.spark.rdd
 
-import java.util.concurrent.TimeUnit
-
-import com.couchbase.client.core.BackpressureException
-import com.couchbase.client.core.time.Delay
 import com.couchbase.client.java.document.json.JsonObject
-import com.couchbase.client.java.error.{CouchbaseOutOfMemoryException, TemporaryFailureException}
 import com.couchbase.client.java.query.N1qlQuery
-import com.couchbase.client.java.util.retry.RetryBuilder
-import com.couchbase.spark.connection.{CouchbaseConfig, CouchbaseConnection, QueryAccessor}
-import com.couchbase.spark.internal.LazyIterator
+import com.couchbase.spark.connection.{CouchbaseConfig, QueryAccessor}
 import org.apache.spark.{Logging, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
-import rx.lang.scala.JavaConversions._
 
 case class CouchbaseQueryRow(value: JsonObject)
 

--- a/src/main/scala/com/couchbase/spark/rdd/SpatialViewRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/SpatialViewRDD.scala
@@ -15,19 +15,11 @@
  */
 package com.couchbase.spark.rdd
 
-import java.util.concurrent.TimeUnit
-
-import com.couchbase.client.core.BackpressureException
-import com.couchbase.client.core.time.Delay
 import com.couchbase.client.java.document.json.JsonObject
-import com.couchbase.client.java.error.{CouchbaseOutOfMemoryException, TemporaryFailureException}
-import com.couchbase.client.java.util.retry.RetryBuilder
 import com.couchbase.client.java.view.SpatialViewQuery
-import com.couchbase.spark.connection.{CouchbaseConfig, CouchbaseConnection, SpatialViewAccessor}
-import com.couchbase.spark.internal.LazyIterator
+import com.couchbase.spark.connection.{CouchbaseConfig, SpatialViewAccessor}
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
-import rx.lang.scala.JavaConversions._
 
 case class CouchbaseSpatialViewRow(id: String, key: Any, value: Any, geometry: JsonObject)
 

--- a/src/main/scala/com/couchbase/spark/rdd/SubdocLookupRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/SubdocLookupRDD.scala
@@ -73,7 +73,7 @@ class SubdocLookupRDD(@transient sc: SparkContext, specs: Seq[SubdocLookupSpec],
           rv.toInt & numPartitions - 1
         }).map(grouped => {
           val hostname = Some(
-            bucketConfig.nodeAtIndex(bucketConfig.nodeIndexForMaster(grouped._1)).hostname()
+            bucketConfig.nodeAtIndex(bucketConfig.nodeIndexForMaster(grouped._1, false)).hostname()
           )
           val currentIdx = partitionIndex
           partitionIndex += 1

--- a/src/main/scala/com/couchbase/spark/rdd/ViewRDD.scala
+++ b/src/main/scala/com/couchbase/spark/rdd/ViewRDD.scala
@@ -15,18 +15,10 @@
  */
 package com.couchbase.spark.rdd
 
-import java.util.concurrent.TimeUnit
-
-import com.couchbase.client.core.BackpressureException
-import com.couchbase.client.core.time.Delay
-import com.couchbase.client.java.error.{CouchbaseOutOfMemoryException, TemporaryFailureException}
-import com.couchbase.client.java.util.retry.RetryBuilder
 import com.couchbase.client.java.view.ViewQuery
-import com.couchbase.spark.connection.{CouchbaseConfig, CouchbaseConnection, ViewAccessor}
-import com.couchbase.spark.internal.LazyIterator
+import com.couchbase.spark.connection.{CouchbaseConfig, ViewAccessor}
 import org.apache.spark.{Dependency, Partition, SparkContext, TaskContext}
 import org.apache.spark.rdd.RDD
-import rx.lang.scala.JavaConversions._
 
 case class CouchbaseViewRow(id: String, key: Any, value: Any)
 

--- a/src/main/scala/com/couchbase/spark/sql/DataFrameWriterFunctions.scala
+++ b/src/main/scala/com/couchbase/spark/sql/DataFrameWriterFunctions.scala
@@ -15,8 +15,7 @@
  */
 package com.couchbase.spark.sql
 
-import org.apache.spark.sql.{DataFrame, DataFrameWriter}
-import org.apache.spark.sql.sources.BaseRelation
+import org.apache.spark.sql.DataFrameWriter
 
 class DataFrameWriterFunctions(@transient val dfw: DataFrameWriter) extends Serializable  {
 

--- a/src/main/scala/com/couchbase/spark/sql/DefaultSource.scala
+++ b/src/main/scala/com/couchbase/spark/sql/DefaultSource.scala
@@ -78,7 +78,7 @@ class DefaultSource
       .toJSON
       .map(rawJson => {
         val encoded = JsonObject.fromJson(rawJson)
-        val id = encoded.getString(idFieldName)
+        val id = encoded.get(idFieldName).toString
         encoded.removeKey(idFieldName)
         JsonDocument.create(id, encoded)
       })

--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -153,14 +153,15 @@ object N1QLRelation {
    */
   def filterToExpression(filter: Filter): String = {
     filter match {
-      case EqualTo(attr, value) => s" `$attr` = " + valueToFilter(value)
-      case GreaterThan(attr, value) => s" `$attr` > " + valueToFilter(value)
-      case GreaterThanOrEqual(attr, value) => s" `$attr` >= " + valueToFilter(value)
-      case LessThan(attr, value) => s" `$attr` < " + valueToFilter(value)
-      case LessThanOrEqual(attr, value) => s" `$attr` <= " + valueToFilter(value)
-      case IsNull(attr) => s" `$attr` IS NULL"
-      case IsNotNull(attr) => s" `$attr` IS NOT NULL"
-      case StringContains(attr, value) => s" CONTAINS(`$attr`, '$value')"
+
+      case EqualTo(attr, value) => s" ${attrToFilter(attr)} = " + valueToFilter(value)
+      case GreaterThan(attr, value) => s" ${attrToFilter(attr)} > " + valueToFilter(value)
+      case GreaterThanOrEqual(attr, value) => s" ${attrToFilter(attr)} >= " + valueToFilter(value)
+      case LessThan(attr, value) => s" ${attrToFilter(attr)} < " + valueToFilter(value)
+      case LessThanOrEqual(attr, value) => s" ${attrToFilter(attr)} <= " + valueToFilter(value)
+      case IsNull(attr) => s" ${attrToFilter(attr)} IS NULL"
+      case IsNotNull(attr) => s" ${attrToFilter(attr)} IS NOT NULL"
+      case StringContains(attr, value) => s" CONTAINS(${attrToFilter(attr)}, '$value')"
       case StringStartsWith(attr, value) => s" `$attr` LIKE '" + escapeForLike(value) + "%'"
       case StringEndsWith(attr, value) => s" `$attr` LIKE '%" + escapeForLike(value) + "'"
       case In(attr, values) =>
@@ -183,9 +184,15 @@ object N1QLRelation {
   def escapeForLike(value: String): String =
     value.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\\\*")
 
-  def valueToFilter(value: Any): String = value match {
-    case v: String => s"'$v'"
-    case v => s"$v"
+  def attrToFilter(attr: String): String = {
+    attr.split('.').map(elem => s"`$elem`").mkString(".")
+  }
+
+  def valueToFilter(value: Any): String = {
+    value match {
+      case v: String => s"'$v'"
+      case v => s"$v"
+    }
   }
 
 }

--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -161,8 +161,8 @@ object N1QLRelation {
       case IsNull(attr) => s" `$attr` IS NULL"
       case IsNotNull(attr) => s" `$attr` IS NOT NULL"
       case StringContains(attr, value) => s" CONTAINS(`$attr`, '$value')"
-      case StringStartsWith(attr, value) => s" `$attr` LIKE '$value%'"
-      case StringEndsWith(attr, value) => s" `$attr` LIKE '%$value'"
+      case StringStartsWith(attr, value) => s" `$attr` LIKE '" + escapeForLike(value) + "%'"
+      case StringEndsWith(attr, value) => s" `$attr` LIKE '%" + escapeForLike(value) + "'"
       case In(attr, values) => {
         val encoded = values.map(valueToFilter).mkString(",")
         s" `$attr` IN [$encoded]"
@@ -184,11 +184,12 @@ object N1QLRelation {
     }
   }
 
-  def valueToFilter(value: Any): String = {
-    value match {
-      case v: String => s"'$v'"
-      case v => s"$v"
-    }
+  def escapeForLike(value: String): String =
+    value.replaceAll("\\.", "\\\\.").replaceAll("\\*", "\\\\*")
+
+  def valueToFilter(value: Any): String = value match {
+    case v: String => s"'$v'"
+    case v => s"$v"
   }
 
 }

--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -163,24 +163,20 @@ object N1QLRelation {
       case StringContains(attr, value) => s" CONTAINS(`$attr`, '$value')"
       case StringStartsWith(attr, value) => s" `$attr` LIKE '" + escapeForLike(value) + "%'"
       case StringEndsWith(attr, value) => s" `$attr` LIKE '%" + escapeForLike(value) + "'"
-      case In(attr, values) => {
+      case In(attr, values) =>
         val encoded = values.map(valueToFilter).mkString(",")
         s" `$attr` IN [$encoded]"
-      }
-      case And(left, right) => {
+      case And(left, right) =>
         val l = filterToExpression(left)
         val r = filterToExpression(right)
         s" ($l AND $r)"
-      }
-      case Or(left, right) => {
+      case Or(left, right) =>
         val l = filterToExpression(left)
         val r = filterToExpression(right)
         s" ($l OR $r)"
-      }
-      case Not(f) => {
+      case Not(f) =>
         val v = filterToExpression(f)
         s" NOT ($v)"
-      }
     }
   }
 

--- a/src/test/scala/com/couchbase/spark/samples/StreamingSample.scala
+++ b/src/test/scala/com/couchbase/spark/samples/StreamingSample.scala
@@ -34,7 +34,7 @@ object StreamingSample {
     val ssc = new StreamingContext(conf, Seconds(5))
 
     ssc
-      .couchbaseStream(from = FromBeginning, storageLevel = StorageLevel.MEMORY_ONLY)
+      .couchbaseStream(from = FromNow, storageLevel = StorageLevel.MEMORY_ONLY)
       .map(_.getClass)
       .countByValue()
       .print()

--- a/src/test/scala/com/couchbase/spark/sql/FilterSpec.scala
+++ b/src/test/scala/com/couchbase/spark/sql/FilterSpec.scala
@@ -66,6 +66,22 @@ class FilterSpec extends FlatSpec with Matchers {
     filterToExpression(StringEndsWith("foo", "bar")) should equal(" `foo` LIKE '%bar'")
   }
 
+  it should "escape . for StringStartsWith" in {
+    filterToExpression(StringStartsWith("foo", "b.ar")) should equal(" `foo` LIKE 'b\\.ar%'")
+  }
+
+  it should "escape * for StringStartsWith" in {
+    filterToExpression(StringStartsWith("foo", "b*ar")) should equal(" `foo` LIKE 'b\\*ar%'")
+  }
+
+  it should "escape . for StringEndsWith" in {
+    filterToExpression(StringEndsWith("foo", "b.ar")) should equal(" `foo` LIKE '%b\\.ar'")
+  }
+
+  it should "escape * for StringEndsWith" in {
+    filterToExpression(StringEndsWith("foo", "b*ar")) should equal(" `foo` LIKE '%b\\*ar'")
+  }
+
   it should "convert In" in {
     filterToExpression(In("foo", Array("blub", 1, true))) should equal (" `foo` IN ['blub',1,true]")
   }

--- a/src/test/scala/com/couchbase/spark/sql/FilterSpec.scala
+++ b/src/test/scala/com/couchbase/spark/sql/FilterSpec.scala
@@ -101,4 +101,27 @@ class FilterSpec extends FlatSpec with Matchers {
     filterToExpression(expr) should equal (" NOT ( ( `name` IS NULL AND  `age` IS NULL))")
   }
 
+  it should "parse paths in nested filter attributes" in {
+    val filter = EqualTo("flavour.type", "10")
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" `flavour`.`type` = '10'")
+  }
+
+  it should "parse paths without nested filter attributes" in {
+    val filter = EqualTo("type", "10")
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" `type` = '10'")
+  }
+
+  it should "parse deeply filter attributes" in {
+    val filter = EqualTo("flavour.origin.country.region", "tuscany")
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" `flavour`.`origin`.`country`.`region` = 'tuscany'")
+  }
 }


### PR DESCRIPTION
Using deeply nested filter attributes like, for example, EqualTo("root.elem.subelem", 10) leads to the generation of the query string: \`root.elem.subelem\` = 10, which is incorrect. This simple patch allows `N1QLRelation.filterToExpression` to generate the more proper: \`root\`.\`elem\`.\`subelem\` = 10.