### PR TITLE
[NEW FEATURE] Not parseable filter attributes

### DIFF
--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -190,8 +190,11 @@ object N1QLRelation {
     case v => s"$v"
   }
 
-  def attrToFilter(attr: String): String = {
-    attr.split('.').map(elem => s"`$elem`").mkString(".")
+  val VerbatimRegex = """'(.*)'""".r
+
+  def attrToFilter(attr: String): String = attr match {
+    case VerbatimRegex(innerAttr) => innerAttr
+    case v => v.split('.').map(elem => s"`$elem`").mkString(".")
   }
 
 }

--- a/src/test/scala/com/couchbase/spark/sql/CouchbaseDataFrameSpec.scala
+++ b/src/test/scala/com/couchbase/spark/sql/CouchbaseDataFrameSpec.scala
@@ -16,7 +16,7 @@
 package com.couchbase.spark.sql
 
 import org.apache.avro.generic.GenericData.StringType
-import org.apache.spark.sql.{SparkSession, SQLContext, SaveMode}
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode, SparkSession}
 import org.apache.spark.sql.sources.EqualTo
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -85,6 +85,16 @@ class CouchbaseDataFrameSpec extends FlatSpec with Matchers with BeforeAndAfterA
     df.write
       .mode(SaveMode.Ignore)
       .couchbase(options = Map("idField" -> "_1", "bucket" -> "default"))
+  }
+  
+  it should "filter based on a function" in {
+    val ssc = spark.sqlContext
+    import com.couchbase.spark.sql._
+    
+    val airlineBySubstrCountry: DataFrame = ssc.read.couchbase(
+      EqualTo("'substr(country, 0, 6)'", "United"), Map("bucket" -> "travel-sample"))
+    
+    airlineBySubstrCountry.count() should equal(6797)
   }
 
 }

--- a/src/test/scala/com/couchbase/spark/sql/FilterSpec.scala
+++ b/src/test/scala/com/couchbase/spark/sql/FilterSpec.scala
@@ -124,4 +124,12 @@ class FilterSpec extends FlatSpec with Matchers {
 
     parsedFilter should equal(" `flavour`.`origin`.`country`.`region` = 'tuscany'")
   }
+  
+  it should "not parse text marked as verbatim" in {
+    val filter = EqualTo("'substr('textField',0,10)'", "2016-09-13")
+
+    val parsedFilter = N1QLRelation.filterToExpression(filter)
+
+    parsedFilter should equal(" substr('textField',0,10) = '2016-09-13'")
+  }
 }


### PR DESCRIPTION
With this PR, a developer can specify if a filter attribute should not be wrapped in backticks. This is useful, for example, when a statement containing a function call is used as filter attribute.

For example, let's say we'd like to generate the following query:
select * from mybucket where `type`='type0' and substr(`long_text_field`, 0, 10) = '2016-09-13'

Using the spark connector this is not viable since using the following syntax:
sqlContext.read.couchbase(schemaFilter = And(EqualTo("type", "type0"),EqualTo("substr('long_text_field',0,10)", "2016-09-13")))

would generate:
select ... from mybucket where `type`='type0' and `substr(`long_text_field`, 0, 10)` = '2016-09-13'

which, obviously, won't work.

This PR adds the ability to pass attribute filters embedded in single quotes. In this case the attribute filter will be extracted and used to generated the final query without being wrapped in backticks.

For example, the following:
sqlContext.read.couchbase(schemaFilter = And(EqualTo("type", "type0"),EqualTo("'substr(`long_text_field`,0,10)'", "2016-09-13")))

(note the single quotes wrapping substr function call)

would generate:
select ... from mybucket where `type`='type0' and substr(`long_text_field`, 0, 10) = '2016-09-13'
