### PR TITLE
Fix CouchbaseSink so it can use Spark state management for aggregations

### DIFF
--- a/src/main/scala/com/couchbase/spark/sql/streaming/CouchbaseSink.scala
+++ b/src/main/scala/com/couchbase/spark/sql/streaming/CouchbaseSink.scala
@@ -18,7 +18,15 @@ package com.couchbase.spark.sql.streaming
 import com.couchbase.spark.Logging
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.types.StringType
 import com.couchbase.spark.sql._
+import com.couchbase.spark._
+import com.couchbase.client.core.CouchbaseException
+import com.couchbase.client.java.document.JsonDocument
+import com.couchbase.client.java.document.json.JsonObject
+import scala.concurrent.duration._
+
 
 /**
   * A simple Structured Streaming sink which writes the data frame to the bucket.
@@ -31,7 +39,30 @@ import com.couchbase.spark.sql._
 class CouchbaseSink(options: Map[String, String]) extends Sink with Logging {
 
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
-    data.write.mode(SaveMode.Overwrite).couchbase(options)
+    val bucketName = options.get("bucket").orNull
+    val idFieldName = options.getOrElse("idField", DefaultSource.DEFAULT_DOCUMENT_ID_FIELD)
+    val removeIdField = options.getOrElse("removeIdField", "true").toBoolean
+    val timeout = options.get("timeout").map(v => Duration(v.toLong, MILLISECONDS))
+    
+    data.toJSON
+      .queryExecution
+      .toRdd
+      .map(_.get(0, StringType).asInstanceOf[UTF8String].toString())
+      .map { rawJson => 
+          val encoded = JsonObject.fromJson(rawJson)
+          val id = encoded.get(idFieldName)
+
+          if (id == null) {
+              throw new Exception(s"Could not find ID field $idFieldName in $encoded")
+          }
+          
+          if (removeIdField) {
+              encoded.removeKey(idFieldName)
+          }
+          
+          JsonDocument.create(id.toString, encoded)
+      }
+      .saveToCouchbase(bucketName, StoreMode.UPSERT, timeout)
   }
 
 }


### PR DESCRIPTION
Hello, my name is Joel LaFall and this is my first time commiting to this project.  I work for a company called Hart which uses Apache Spark and Couchbase extensively. When evaluating Spark Structured Streaming and the Couchbase sink with a simple word count example using Kafka as the source and Couchbase as the sink, I noticed that the state of the aggregation was not being saved.  And so every time a new instance of a word already seen came into Kafka and counted by the Spark driver, the count would effectively "reset" to 1. Looking into the Apache Spark source, I found that calling Dataset.rdd will breaking the state management machinery and the only way I found to get around this is to call Dataset.queryExecution.toRdd, which returns an RDD[InternRow] that does not break state management.  After making the change to the Couchbase connector, everything worked as expected.

See also:

- https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ForeachSink.scala
- https://github.com/apache/spark/blob/master/external/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala