### PR TITLE
Added python support for RDD/context functions on pyspark

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -1,0 +1,134 @@
+=================
+pyspark_couchbase
+=================
+
+This package provides support for working with pyspark RDDs using 
+couchbase server as data source.
+
+--------
+Building
+--------
+
+Building assembly jar for couchbase spark connector.
+
+.. code-block:: sh
+
+    sbt assembly
+
+Building an egg file to submit it with spark-submit.
+
+.. code-block:: sh
+
+    cd python && python setup.py bdist_egg
+
+
+Installing to current environment for interactive use.
+
+.. code-block:: sh
+
+    cd python && python setup.py install
+
+----------------
+Using with spark
+----------------
+
+After building an assembly jar and an egg file;
+
+.. code-block:: sh
+
+    spark-submit \
+       --jars path/to/spark-connector-assembly<version>.jar \
+       --py-files path/to/pyspark_couchbase<version>.egg
+
+Using spark packages instead of assembly jar;
+
+.. code-block:: sh
+
+    spark-submit \
+       --packages com.couchbase.client:spark-connector:<version> \
+       --py-files path/to/pyspark_couchbase<version>.egg
+
+In order to make pyspark_couchbase functions available in
+sparkContext and RDD's, import pypspark_couchbase in the shell or
+submitted python script. 
+
+.. code-block:: python
+
+    import pyspark_couchbase
+
+--------
+Examples
+--------
+
+Creating a spark session, connecting to a local couchbase server and
+setting configuration for a bucket and its password;
+
+.. code-block:: python
+
+    import pyspark_couchbase
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder\
+       .master("local")\
+       .appName("test")\
+       .config("spark.couchbase.nodes", "127.0.0.1")\
+       .config("spark.couchbase.bucket.bucketname", "bucketpassword")\
+       .getOrCreate()
+
+Saving RDD of RawJsonDocuments couchbase
+
+.. code-block:: python
+
+    from pyspark_couchbase.types import RawJsonDocument
+
+    spark.sparkContext.parallelize(
+        [RawJsonDocument("doc_1", json.dumps({"val": "doc_1"}))])\
+        .saveToCouchbase()
+
+
+Getting data from couchbase using spark context or RDD of document ids;
+
+.. code-block:: python
+
+    docs = spark.sparkContext.couhcbaseGet(["doc_1"]).collect()
+
+
+.. code-block:: python
+
+    docs = spark.sparkContext.parallelize(["doc_1"]).couchbaseGet().collect()
+
+.. code-block:: python
+
+    >> docs[0].id
+    u'doc_1'
+    >> docs[0].content
+    u'{"val": "doc_1"}'
+
+
+Subdoclookup queries;
+
+.. code-block:: python
+
+    from pyspark_couchbase.types import RawJsonDocument
+    import json
+    spark.sparkContext.parallelize(
+        [RawJsonDocument(
+             "subdoc_10", json.dumps({"subdoc": {"val": "subdoc_10"}})])])\
+        .saveToCouchbase()
+
+.. code-block:: python
+
+    results = spark.sparkContext.parallelize(["subdoc_10"]).couchbaseSubdocLookup(
+        ["subdoc"]).collect()
+
+.. code-block:: python 
+
+    results = spark.sparkContext.couchbaseSubdocLookup(
+        ["subdoc_10"], ["subdoc"]).collect()
+
+.. code-block:: python
+
+    >> results[0].id
+    u'subdoc_10'
+    >> results[0].content
+    {u'subdoc': {u'val': u'subdoc_10'}}

--- a/python/pyspark_couchbase/__init__.py
+++ b/python/pyspark_couchbase/__init__.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2015 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pyspark_couchbase.context import monkey_patch_context
+from pyspark_couchbase.rdd import monkey_patch_rdd
+
+
+def monkey_patch_all():
+    monkey_patch_context()
+    monkey_patch_rdd()
+
+
+monkey_patch_all()

--- a/python/pyspark_couchbase/context.py
+++ b/python/pyspark_couchbase/context.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2015 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Spark context functions
+"""
+import pyspark
+from pyspark.rdd import RDD
+
+from pyspark_couchbase.utils import (
+    _get_java_array, _scala_api)
+
+
+def monkey_patch_context():
+    """
+    Add methods to SparkContext class
+    """
+    pyspark.context.SparkContext.couchbaseGet = couchbaseGet
+    pyspark.context.SparkContext.couchbaseSubdocLookup = \
+        couchbaseSubdocLookup
+
+
+def couchbaseGet(sc, ids, bucketName=None, numSlices=0,
+                 timeout=0, timeoutUnit="millis"):
+    """
+    Query couchbase with a list of document ids,
+    returns RDD of RawJsonDocuments.
+
+    Calls sparkContext.couchbaseGet[RawJsonDocument] on scala
+
+    Parameters
+    ----------
+    sc: sparkContext
+    ids: List of strings
+        List of strings corresponding to document ids
+    bucketName: string
+        Bucket to connect. If None,
+        it connects to the only configured bucket
+    numSlices: int
+        parallelism, defaults to spark defaultParallelism
+        if 0
+    timeout: int
+        timeout amount
+    timeoutUnit: string
+        unit of timeout in scala.concurrent.duration.Duration
+        specified as string. Available options are;
+        "days", "hours", "micros", "millis", "minutes",
+        "nanos", "seconds".
+
+    Returns
+    -------
+    RDD
+        Returns RDD of RawJsonDocument for found documents
+    """
+    # Convert list of strings to java as Array[String]
+    java_ids = _get_java_array(sc._gateway, "String", ids)
+
+    # Call sparkContext.couchbaseGet.
+    rdd_results = _scala_api(
+        sc).couchbaseGet(
+        sc._jsc.sc(), java_ids, bucketName, numSlices, timeout, timeoutUnit)
+
+    # Serialize scala RDD
+    rdd_pickled = _scala_api(
+        sc).pickleRows(rdd_results)
+
+    # Convert RDD to JavaRDD and create python RDD
+    jrdd = _scala_api(
+        sc).javaRDD(rdd_pickled)
+    return RDD(jrdd, sc)
+
+
+def couchbaseSubdocLookup(sc, ids, get,
+                          exists=None, bucketName=None,
+                          timeout=0, timeoutUnit="millis"):
+    """
+    Create a subdoclookup query from list of document
+    ids.
+
+    Calls sparkContext.couchbaseSubdocLookup on scala
+
+    Parameters
+    ----------
+    sc: sparkContext
+    ids: List of strings
+        rdd of strings corresponding to document ids
+    get: List of strings
+        fields to fetch from document
+    exists: List of strings
+        optionally check if keys exist in the document
+    bucketName: string
+        Bucket to connect. If None,
+        it connects to the only configured bucket
+    timeout: int
+        timeout amount
+    timeoutUnit: string
+        unit of timeout in scala.concurrent.duration.Duration
+        specified as string. Available options are;
+        "days", "hours", "micros", "millis", "minutes",
+        "nanos", "seconds".
+
+    Returns
+    -------
+    RDD
+        Returns RDD of SubdocLookupResult for found documents
+    """
+    if exists is None:
+        exists = []
+    # Convert list of strings to java as Array[String]
+    ids_java = _get_java_array(sc._gateway, "String", ids)
+    get_java = _get_java_array(sc._gateway, "String", get)
+    exists_java = _get_java_array(sc._gateway, "String", exists)
+
+    # Call sparkContext.couchbaseSubdocLookup
+    rdd_results = _scala_api(
+        sc).couchbaseSubdocLookup(
+        sc._jsc.sc(), ids_java, get_java, exists_java, bucketName,
+        timeout, timeoutUnit)
+
+    # Serialize scala RDD
+    rdd_pickled = _scala_api(
+        sc).pickleRows(rdd_results)
+
+    # Convert RDD to JavaRDD and create python RDD
+    jrdd = _scala_api(
+        sc).javaRDD(rdd_pickled)
+    return RDD(jrdd, sc)

--- a/python/pyspark_couchbase/rdd.py
+++ b/python/pyspark_couchbase/rdd.py
@@ -1,0 +1,161 @@
+#
+# Copyright (c) 2015 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Spark RDD functions
+"""
+import pyspark
+from pyspark.rdd import RDD
+from pyspark_couchbase.utils import (
+    _scala_api, _get_java_array)
+
+
+def monkey_patch_rdd():
+    """
+    Add methods to RDD class
+    """
+    pyspark.rdd.RDD.couchbaseGet = couchbaseGet
+    pyspark.rdd.RDD.saveToCouchbase = saveToCouchbase
+    pyspark.rdd.RDD.couchbaseSubdocLookup = couchbaseSubdocLookup
+
+
+def _get_python_rdd(ctx, rdd_scala):
+    """
+    Convenience method to serialize scala RDD and
+    convert to python RDD
+    """
+    rdd_pickled = _scala_api(
+        ctx).pickleRows(rdd_scala)
+    jrdd = _scala_api(
+        ctx).javaRDD(rdd_pickled)
+    return RDD(jrdd, ctx)
+
+
+def couchbaseGet(
+        rdd, bucketName=None, timeout=0,
+        timeoutUnit="millis"):
+    """
+    Query couchbase with an RDD of document ids.
+
+    Calls RDD[String].couchbaseGet[RawJsonDocument] on scala
+
+    Parameters
+    ----------
+    rdd: RDD
+        rdd of strings corresponding to document ids
+    bucketName: string
+        Bucket to connect. If None,
+        it connects to the only configured bucket
+    timeout: int
+        timeout amount
+    timeoutUnit: string
+        unit of timeout in scala.concurrent.duration.Duration
+        specified as string. Available options are;
+        "days", "hours", "micros", "millis", "minutes",
+        "nanos", "seconds".
+
+    Returns
+    -------
+    RDD
+        Returns RDD of RawJsonDocument for found documents
+
+    """
+    # Convert python RDD to JavaRDD. No need to deserialize
+    # as it's RDD[String]
+    rdd_java = rdd.ctx._jvm.SerDe.pythonToJava(rdd._jrdd, True)
+
+    # call RDD[String].couchbaseGet
+    rdd_scala = _scala_api(
+        rdd.ctx).couchbaseGet(
+        rdd_java.rdd(), bucketName, timeout, timeoutUnit)
+    return _get_python_rdd(rdd.ctx, rdd_scala)
+
+
+def saveToCouchbase(
+        rdd, bucketName=None, storeMode="UPSERT",
+        timeout=0, timeoutUnit="millis"):
+    """
+    Save RDD of RawJsonDocuments to couchbase.
+
+    Calls RDD[RawJsonDocument].saveToCouchbase
+
+    Parameters
+    ----------
+    rdd: RDD
+        rdd of strings corresponding to document ids
+    bucketName: string
+        Bucket to connect. If None,
+        it connects to the only configured bucket
+    timeout: int
+        timeout amount
+    storeMode: string
+        one of "UPSERT", "INSERT_AND_FAIL", "INSERT_AND_IGNORE",
+        "REPLACE_AND_FAIL", "REPLACE_AND_IGNORE" corresponding
+        to store modes.
+    timeoutUnit: string
+        unit of timeout in scala.concurrent.duration.Duration
+        specified as string. Available options are;
+        "days", "hours", "micros", "millis", "minutes",
+        "nanos", "seconds".
+    """
+    unpickled = _scala_api(
+        rdd.ctx).unpickleRows(rdd._jrdd.rdd())
+    _scala_api(
+        rdd.ctx).saveToCouchbase(
+        unpickled, bucketName, storeMode, timeout, timeoutUnit)
+
+
+def couchbaseSubdocLookup(rdd, get, exists=None, bucketName=None,
+                          timeout=0, timeoutUnit="millis"):
+    """
+    Create a subdoclookup query from RDD of document
+    ids.
+
+    Calls RDD[String].couchbaseSubdocLookup on scala
+
+    Parameters
+    ----------
+    rdd: RDD
+        rdd of strings corresponding to document ids
+    get: List of strings
+        fields to fetch from document
+    exists: List of strings
+        optionally check if keys exist in the document
+    bucketName: string
+        Bucket to connect. If None,
+        it connects to the only configured bucket
+    timeout: int
+        timeout amount
+    timeoutUnit: string
+        unit of timeout in scala.concurrent.duration.Duration
+        specified as string. Available options are;
+        "days", "hours", "micros", "millis", "minutes",
+        "nanos", "seconds".
+
+    Returns
+    -------
+    RDD
+        Returns RDD of SubdocLookupResult for found documents
+    """
+    if exists is None:
+        exists = []
+    get_java = _get_java_array(rdd.ctx._gateway, "String", get)
+    exists_java = _get_java_array(rdd.ctx._gateway, "String", exists)
+    rdd_java = rdd.ctx._jvm.SerDe.pythonToJava(rdd._jrdd, True)
+    rdd_scala = _scala_api(
+        rdd.ctx).couchbaseSubdocLookup(
+        rdd_java.rdd(), get_java, exists_java, bucketName,
+        timeout, timeoutUnit)
+    return _get_python_rdd(rdd.ctx, rdd_scala)

--- a/python/pyspark_couchbase/types.py
+++ b/python/pyspark_couchbase/types.py
@@ -1,0 +1,154 @@
+#
+# Copyright (c) 2015 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+
+
+class RawJsonDocument(object):
+    """
+    Represents a document which is already json encoded.
+    """
+
+    def __init__(self, id, content, cas=0, expiry=0,
+                 mutation_token=None):
+        """
+        Creates a document from already encoded content
+
+        Parameters
+        ----------
+        id: string
+            per bucket unique document id
+        content: string
+            json encoded contents
+        cas: int
+            the CAS value
+        expiry: int
+            expiration time of the document
+        mutation_token: pypsark_couchbase.types.MutationToken
+            mutation token of the document
+        """
+        self.id = id
+        self.content = content
+        self.cas = cas
+        self.expiry = expiry
+        self.mutation_token = mutation_token
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def to_dict(self):
+        return vars(self)
+
+    def __reduce__(self):
+        return (
+            RawJsonDocument, (
+                self.id, self.content,
+                self.cas, self.expiry, self.mutation_token))
+
+    def __repr__(self):
+        return str(self.to_dict())
+
+
+def _build_subdoclookup_value(value):
+    """
+    Helper function to decode json objects.
+    Java null is mappped to python None in Pyrolite. Therefore
+    we may get None objects if the query does not return
+    any results, thus requiring special checking while decoding.
+    """
+    return json.loads(value) if value is not None else None
+
+
+def _create_subdoclookup_result(
+        id, keys, values, cas, exists):
+    """
+    Factory function used by scala pickler to create
+    SubdocLookupResult instances.
+
+    Parameters
+    ----------
+    id: string
+        Doc id
+    keys: List[string]
+        List of subdoclookup query ids
+    values: List[string]
+        List of json encoded subdoclookup
+        query results. Decoded to dict
+        with json
+    exists: Dict[string: bool]
+        Results of exists query
+    """
+    content = {
+        k: _build_subdoclookup_value(v)
+            for k, v in zip(keys, values)}
+    return SubdocLookupResult(
+        id, content, cas, exists)
+
+
+class SubdocLookupResult(object):
+    """
+    Used for returning results of subdoclookup query
+    """
+
+    def __init__(self, id, content, cas, exists):
+        """
+        Parameters
+        ----------
+        id: string
+            Per bucket unique document id
+        content: Dict[str: Dict]
+            Subdoclookup results, which maps
+            the subdoclookup query ids to objects
+            which are json decoded
+        cas: int
+            The CAS value
+        exists: Dict[str: bool]
+            Result of the 'exists' query, mapping
+            ids to results
+        """
+        self.id = id
+        self.content = content
+        self.cas = cas
+        self.exists = exists
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def to_dict(self):
+        return vars(self)
+
+    def __repr__(self):
+        return str(self.to_dict())
+
+
+class MutationToken(object):
+
+    def __init__(
+            self, vbucket_id, vbucket_uuid,
+            sequence_number, bucket):
+        self.vbucket_id = vbucket_id
+        self.vbucket_uuid = vbucket_uuid
+        self.sequence_number = sequence_number
+        self.bucket = bucket
+
+    def __reduce(self):
+        return (
+            MutationToken, (
+                self.vbucket_id,
+                self.vbucket_uuid, self.sequence_number,
+                self.bucket))
+
+    def __repr__(self):
+        return str(vars(self))

--- a/python/pyspark_couchbase/utils.py
+++ b/python/pyspark_couchbase/utils.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2015 Couchbase, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Utilities for using scala api
+"""
+
+def _load_class(ctx, name):
+    return ctx._jvm.java.lang.Thread.currentThread() \
+        .getContextClassLoader().loadClass(name)
+
+
+def _get_java_array(gateway, java_type, iterable):
+    java_type = gateway.jvm.__getattr__(java_type)
+    lst = list(iterable)
+    arr = gateway.new_array(java_type, len(lst))
+    for i, e in enumerate(lst):
+        arr[i] = e
+    return arr
+
+
+def _scala_api(ctx):
+    if not hasattr(_scala_api, "instance"):
+        _scala_api.instance = _load_class(
+            ctx, "com.couchbase.spark.api.python.PythonAPI").newInstance()
+    return _scala_api.instance

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,5 @@
+[nosetests]
+nologcapture=1
+detailed-errors=1
+with-coverage=1
+cover-package=pyspark_couchbase

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+
+VERSION = "2.2.0"
+
+
+setup(
+    name='pyspark_couchbase',
+    version=VERSION,
+    url="https://github.com/couchbase/couchbase-spark-connector",
+    license="Apache License 2.0",
+    description="Utilities for using pyspark with couchbase",
+    long_description=open("README.rst", "r").read(),
+    keywords=["couchbase", "nosql", "pyspark"],
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Topic :: Database",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules"],
+    packages=[
+        'pyspark_couchbase'],
+    install_requires=[],
+    tests_require=['nose'],
+    test_suite='tests',
+    zip_safe=True
+)

--- a/python/tests/test_cbase_integration.py
+++ b/python/tests/test_cbase_integration.py
@@ -1,0 +1,85 @@
+import unittest
+import json
+import glob
+import os
+
+from pyspark.sql import SparkSession
+import pyspark_couchbase
+from pyspark_couchbase.types import (
+    RawJsonDocument)
+
+
+BUCKETNAME = os.environ.get("BUCKETNAME", "default")
+BUCKETPASSWORD = os.environ.get("BUCKETPASSWORD", "password")
+JARS = glob.glob(
+    os.path.join(os.environ.get("JARS_PATH", ""), "*.jar"))
+
+
+class TestLocal(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.spark = SparkSession.builder\
+            .master("local")\
+            .appName("test-integration")\
+            .config("spark.jars", ",".join(JARS))\
+            .config("spark.couchbase.nodes", "127.0.0.1")\
+            .config("spark.couchbase.bucket.{}".format(
+                BUCKETNAME), BUCKETPASSWORD)\
+            .getOrCreate()
+
+    def test_rawjson_save_get_from_context(self):
+        self.spark.sparkContext.parallelize(
+            [RawJsonDocument("doc_10", json.dumps({"val": "doc_10"})),
+             RawJsonDocument("doc_20", json.dumps({"val": "doc_20"})),
+             RawJsonDocument("doc_30", json.dumps({"val": "doc_30"}))])\
+            .saveToCouchbase()
+
+        for doc in self.spark.sparkContext.couchbaseGet(
+                ["doc_10", "doc_20", "doc_30"]).collect():
+            assert doc.id == json.loads(doc.content)["val"]
+
+    def test_rawjson_save_get_from_rdd(self):
+        self.spark.sparkContext.parallelize(
+            [RawJsonDocument("doc_11", json.dumps({"val": "doc_11"})),
+             RawJsonDocument("doc_21", json.dumps({"val": "doc_21"})),
+             RawJsonDocument("doc_31", json.dumps({"val": "doc_31"}))])\
+            .saveToCouchbase()
+
+        for doc in self.spark.sparkContext.parallelize(
+               ["doc_11", "doc_21", "doc_31"]).couchbaseGet().collect():
+            assert doc.id == json.loads(doc.content)["val"]
+
+    def test_subdoclookup_from_context(self):
+        self.spark.sparkContext.parallelize(
+            [RawJsonDocument(
+                "subdoc_10", json.dumps({"subdoc": {"val": "subdoc_10"}})),
+             RawJsonDocument(
+                "subdoc_20", json.dumps({"subdoc": {"val": "subdoc_20"}})),
+             RawJsonDocument(
+                "subdoc_30", json.dumps({"subdoc": {"val": "subdoc_30"}}))])\
+            .saveToCouchbase()
+
+        for doc in self.spark.sparkContext.couchbaseSubdocLookup(
+                ["subdoc_10", "subdoc_20", "subdoc_30"],
+                ["subdoc"]).collect():
+            assert doc.id == doc.content["subdoc"]["val"]
+
+    def test_subdoclookup_from_rdd(self):
+        self.spark.sparkContext.parallelize(
+            [RawJsonDocument(
+                "subdoc_10", json.dumps({"subdoc": {"val": "subdoc_10"}})),
+             RawJsonDocument(
+                "subdoc_20", json.dumps({"subdoc": {"val": "subdoc_20"}})),
+             RawJsonDocument(
+                "subdoc_30", json.dumps({"subdoc": {"val": "subdoc_30"}}))])\
+            .saveToCouchbase()
+
+        for doc in self.spark.sparkContext.parallelize(
+                ["subdoc_10", "subdoc_20", "subdoc_30"]).couchbaseSubdocLookup(
+                ["subdoc"]).collect():
+            assert doc.id == doc.content["subdoc"]["val"]
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.spark.stop()

--- a/src/main/scala/com/couchbase/spark/api/python/PicklerUtils.scala
+++ b/src/main/scala/com/couchbase/spark/api/python/PicklerUtils.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2015 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.spark.api.python
+
+import com.couchbase.client.core.message.kv.MutationToken
+import com.couchbase.client.java.document._
+import com.couchbase.client.java.document.json.JsonArray
+import com.couchbase.spark.connection.SubdocLookupResult
+
+import java.io.OutputStream
+import java.util.{ArrayList => JArrayList}
+
+import net.razorvine.pickle._
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
+class PicklerUtils extends Serializable {
+  register()
+  def pickler() = {
+    register() 
+    new Pickler()
+  }
+
+  def unpickler() = {
+    register() 
+    new Unpickler()
+  }
+  def register(){
+    RawJsonDocumentPickler.register()
+    MutationTokenPickler.register()
+    Pickler.registerCustomPickler(classOf[SubdocLookupResult], SubdocLookupResultPickler)
+  }
+}
+
+object BatchPickler {
+  private val picklers = new PicklerUtils()
+  private val batchSize = 1000 
+  def pickle(in: Iterator[_]): Iterator[Array[Byte]] = {
+    in.grouped(batchSize).map { b => picklers.pickler().dumps(b.toArray) }
+  }
+}
+
+object BatchUnpickler {
+  
+  private val picklers = new PicklerUtils()
+
+  def unpickle(in: Array[Byte]): Seq[Any] = {
+    val unpickled = picklers.unpickler().loads(in)
+    unpickled match {
+      case array: Array[Any] => array.toSeq
+      case _ => unpickled.asInstanceOf[JArrayList[_]].asScala
+    }
+  }
+}
+
+
+/**
+ * Base pickler class for serialization / deserialization between
+ * python and java using Pickle.
+ */
+abstract class BasePickler[T: ClassTag] 
+  extends IObjectPickler with IObjectConstructor {
+  
+  private val cls = implicitly[ClassTag[T]].runtimeClass
+  
+  def pyModule: String
+  
+  def pyType: String
+  
+  def pyTypePath = s"$pyModule\n$pyType\n"
+
+  def register(): Unit = {
+    Pickler.registerCustomPickler(cls, this)
+    Unpickler.registerConstructor(pyModule, pyType, this)
+  }
+
+  /**
+   * Java to python conversion, calls the registered
+   * python function with arguments implemented in getPyArgs.
+   */ 
+  def pickle(o: Any, out: OutputStream, pickler: Pickler): Unit = {
+    // push self.find_class(modname, name) 
+    out.write(Opcodes.GLOBAL) 
+    out.write(pyTypePath.getBytes()) 
+    // push special markobject on stack 
+    out.write(Opcodes.MARK) 
+    getPyArgs(o.asInstanceOf[T]).foreach(pickler.save(_))
+    // build tuple from topmost stack items 
+    out.write(Opcodes.TUPLE)
+    // apply callable to argtuple, both on stack 
+    out.write(Opcodes.REDUCE) 
+  }
+  
+  /**
+   * Array of Any to call the python constructor with.
+   * See https://github.com/irmen/Pyrolite for type mapping
+   * from java to python
+   */
+  def getPyArgs(obj: T): Array[Any]
+  
+  /**
+   * Construct scala object with array of java objects
+   * from __reduce__ output on python
+   */
+  def construct(args: Array[AnyRef]): AnyRef
+}
+
+/**
+ * RawJsonDocument serialization / deserialization
+ */
+object RawJsonDocumentPickler extends BasePickler[RawJsonDocument] {
+
+  def pyModule = "pyspark_couchbase.types"
+  def pyType = "RawJsonDocument"
+
+  def getPyArgs(obj: RawJsonDocument): Array[Any] = {
+    Array(obj.id, obj.content, obj.cas, obj.expiry, obj.mutationToken)
+  }
+  
+  def construct(args: Array[AnyRef]): RawJsonDocument= {
+    val id = args(0).asInstanceOf[String]
+    val content = args(1).asInstanceOf[String]
+    val cas = args(2).asInstanceOf[Number].longValue
+    val expiry = args(3).asInstanceOf[Int]
+    val mt = args(4).asInstanceOf[MutationToken]
+    RawJsonDocument.create(id, expiry, content, cas, mt)
+  }
+}
+
+/**
+ * MutationToken serialization / deserialization
+ */
+object MutationTokenPickler extends BasePickler[MutationToken] {
+
+  def pyModule = "pyspark_couchbase.types"
+  def pyType = "MutationToken"
+
+  def getPyArgs(obj: MutationToken): Array[Any] = {
+    Array(obj.vbucketID, obj.vbucketUUID, obj.sequenceNumber, obj.bucket)
+  }
+  
+  def construct(args: Array[AnyRef]): MutationToken = {
+    val vbucketID = args(0).asInstanceOf[Number].longValue
+    val vbucketUUID = args(1).asInstanceOf[Number].longValue
+    val sequenceNumber = args(2).asInstanceOf[Number].longValue
+    val bucket = args(3).asInstanceOf[String]
+    new MutationToken(vbucketID, vbucketUUID, sequenceNumber, bucket)
+  }
+}
+
+/**
+ * SubdocLookupResult serialization 
+ * Only Java to python is implemented for SubdocLookupResult
+ */
+object SubdocLookupResultPickler extends IObjectPickler {
+  def pickle(o: Any, out: OutputStream, pickler: Pickler): Unit = {
+    out.write(Opcodes.GLOBAL)
+    out.write(pyTypePath.getBytes())
+    out.write(Opcodes.MARK)
+    val result = o.asInstanceOf[SubdocLookupResult]
+    pickler.save(result.id)
+    
+    val (keys, vals) = result.content.toSeq.unzip
+    val serializedVals = vals map {
+      case a: Any => a.toString
+      case _ => null // Converted to None on python side
+    }
+    pickler.save(seqAsJavaList(keys))
+    pickler.save(seqAsJavaList(serializedVals)) 
+    pickler.save(result.cas) 
+    pickler.save(mapAsJavaMap(result.exists))
+    out.write(Opcodes.TUPLE)
+    out.write(Opcodes.REDUCE)
+  }
+
+  def pyTypePath = "pyspark_couchbase.types\n_create_subdoclookup_result\n"
+}

--- a/src/main/scala/com/couchbase/spark/api/python/PythonAPI.scala
+++ b/src/main/scala/com/couchbase/spark/api/python/PythonAPI.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2015 Couchbase, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.couchbase.spark.api.python
+
+import com.couchbase.client.java.document._
+import com.couchbase.spark._
+
+
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.api.python.SerDeUtil
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+
+import scala.concurrent.duration.Duration
+
+
+/**
+ * Functions available to be called from Python side
+ */ 
+class PythonAPI(){
+  
+  /**
+   * Create duration option from timeout and it's unit.
+   */
+  private def timeoutAsDuration(timeout: Int = 0,
+                                timeoutUnit: String = "millis") = {
+    val duration = if (timeout != 0) Duration(timeout, timeoutUnit) else null
+    Option(duration)
+  }
+
+  def couchbaseGet(sc: SparkContext, ids: Array[String], 
+                   bucketName: String, numSlices: Int,
+                   timeout: Int, timeoutUnit: String ) = {
+    val nSlices = if (numSlices == 0) sc.defaultParallelism else numSlices
+    sc.couchbaseGet[RawJsonDocument](ids, bucketName, nSlices,
+                                     timeoutAsDuration(timeout, timeoutUnit))
+  }
+  
+
+  def couchbaseGet(rdd: RDD[String], bucketName: String,
+                   timeout: Int, timeoutUnit: String) = {
+    rdd.couchbaseGet[RawJsonDocument](bucketName, 
+                                      timeoutAsDuration(timeout, timeoutUnit)) 
+  }
+
+  def saveToCouchbase(rdd: RDD[RawJsonDocument], bucketName: String = null,
+                      storeMode: String = "UPSERT",
+                      timeout: Int, timeoutUnit: String) = {
+    rdd.saveToCouchbase(bucketName, StoreMode.valueOf(storeMode),
+                        timeoutAsDuration(timeout, timeoutUnit))
+  }
+
+  def couchbaseSubdocLookup(rdd: RDD[String], get: Array[String],
+                            exists: Array[String], bucketName: String,
+                            timeout: Int, timeoutUnit: String) = {
+    rdd.couchbaseSubdocLookup(get, exists, bucketName,
+                              timeoutAsDuration(timeout, timeoutUnit))
+  }
+
+  def couchbaseSubdocLookup(sc: SparkContext, 
+                            ids: Array[String], get: Array[String],
+                            exists: Array[String], bucketName: String,
+                            timeout: Int, timeoutUnit: String) = {
+    sc.couchbaseSubdocLookup(ids, get, exists, bucketName,
+                             timeoutAsDuration(timeout, timeoutUnit))
+  }
+
+  /**
+   * Serialize scala RDD
+   */  
+  def pickleRows(rdd: RDD[_]) = {
+    rdd.mapPartitions(BatchPickler.pickle, true)
+  }
+
+  /**
+   * Deserialize RDD
+   */ 
+  def unpickleRows(rdd: RDD[Array[Byte]]) = {
+    rdd.flatMap(BatchUnpickler.unpickle)
+  }
+
+  /**
+   * Convert scala RDD to Java to be used in python RDD
+   */ 
+  def javaRDD(rdd: RDD[_]) = JavaRDD.fromRDD(rdd)
+
+}


### PR DESCRIPTION
Hi, first of all thank you very much for this great tool! It's my first time committing to this project. I was wondering if you would be open to supporting python?

If so, I've added some initial support by exposing some functions from scala (couchbaseGet, saveToCouchbase and couchbaseSubdocLookup on RDD/sparkContext) to python, added a python module that wraps it with some simple documentation. The integration tests are on the python side, requiring a running local couchbase server instance and pyspark. I'd need some help in integrating those tests to the CI system. Also, if there's any additional functionalities you'd like to expose let's discuss about it!