### PR TITLE
Spark 2.3 Connector: Allow passthrough of timestampFormat and dateFormat for inferring schema

### DIFF
--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -72,16 +72,23 @@ class N1QLRelation(bucket: String, userSchema: Option[StructType], parameters: M
       .map(_.value.toString)
     val dataset = sqlContext.sparkSession.createDataset(rdd)(Encoders.STRING)
 
+    // datetime and timestamp defaults were taken from sparks Json Parser:
+    // https://github.com/apache/spark/blob/branch-2.3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala#L84
     val timestampFormat = if (parameters.get("timestampFormat").isDefined) {
       parameters("timestampFormat")
     } else {
-      // use the default in Spark 2.3 FastDateParser
       "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    }
+    val dateFormat = if (parameters.get("dateFormat").isDefined) {
+      parameters("dateFormat")
+    } else {
+      "yyyy-MM-dd"
     }
 
     val schema = sqlContext
       .read
       .option("timestampFormat", timestampFormat)
+      .option("dateFormat", dateFormat)
       .json(dataset)
       .schema
 

--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -72,23 +72,17 @@ class N1QLRelation(bucket: String, userSchema: Option[StructType], parameters: M
       .map(_.value.toString)
     val dataset = sqlContext.sparkSession.createDataset(rdd)(Encoders.STRING)
 
-    // datetime and timestamp defaults were taken from sparks Json Parser:
-    // https://github.com/apache/spark/blob/branch-2.3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala#L84
-    val timestampFormat = if (parameters.get("timestampFormat").isDefined) {
-      parameters("timestampFormat")
-    } else {
-      "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    val options = collection.mutable.Map[String, String]()
+    if (parameters.get("timestampFormat").isDefined) {
+      options("timestampFormat") = parameters("timestampFormat")
     }
-    val dateFormat = if (parameters.get("dateFormat").isDefined) {
-      parameters("dateFormat")
-    } else {
-      "yyyy-MM-dd"
+    if (parameters.get("dateFormat").isDefined) {
+      options("dateFormat") = parameters("dateFormat")
     }
 
     val schema = sqlContext
       .read
-      .option("timestampFormat", timestampFormat)
-      .option("dateFormat", dateFormat)
+      .options(options)
       .json(dataset)
       .schema
 

--- a/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
+++ b/src/main/scala/com/couchbase/spark/sql/N1QLRelation.scala
@@ -72,8 +72,16 @@ class N1QLRelation(bucket: String, userSchema: Option[StructType], parameters: M
       .map(_.value.toString)
     val dataset = sqlContext.sparkSession.createDataset(rdd)(Encoders.STRING)
 
+    val timestampFormat = if (parameters.get("timestampFormat").isDefined) {
+      parameters("timestampFormat")
+    } else {
+      // use the default in Spark 2.3 FastDateParser
+      "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    }
+
     val schema = sqlContext
       .read
+      .option("timestampFormat", timestampFormat)
       .json(dataset)
       .schema
 


### PR DESCRIPTION
We are running into an issue where couchbase is trying to infer schema using the `FastDateFormat` default timestamp format of `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` - and since on schema infer the `parameters` is not passed through, we cannot specify our custom timestamp format.  The line in question is here:
https://github.com/apache/spark/blob/branch-2.3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala#L84

Right now, without this custom timestamp format, we run into the following exception using the FastDateFormat library (stacktrace taken from console output):

```
INFO N1QLRelation: Inferring schema from bucket __collection__ with query 'SELECT META(`__collection__`).id as `META_ID`, `__collection__`.* FROM `__collection__` WHERE `type` = '__type__' LIMIT 1000'
Exception in thread "main" java.lang.IllegalArgumentException: Illegal pattern component: XXX
	at org.apache.commons.lang3.time.FastDatePrinter.parsePattern(FastDatePrinter.java:282)
	at org.apache.commons.lang3.time.FastDatePrinter.init(FastDatePrinter.java:149)
	at org.apache.commons.lang3.time.FastDatePrinter.<init>(FastDatePrinter.java:142)
	at org.apache.commons.lang3.time.FastDateFormat.<init>(FastDateFormat.java:369)
	at org.apache.commons.lang3.time.FastDateFormat$1.createInstance(FastDateFormat.java:91)
	at org.apache.commons.lang3.time.FastDateFormat$1.createInstance(FastDateFormat.java:88)
	at org.apache.commons.lang3.time.FormatCache.getInstance(FormatCache.java:82)
	at org.apache.commons.lang3.time.FastDateFormat.getInstance(FastDateFormat.java:165)
	at org.apache.spark.sql.catalyst.json.JSONOptions.<init>(JSONOptions.scala:83)
	at org.apache.spark.sql.catalyst.json.JSONOptions.<init>(JSONOptions.scala:43)
	at org.apache.spark.sql.DataFrameReader.json(DataFrameReader.scala:439)
	at com.couchbase.spark.sql.N1QLRelation$$anonfun$3.apply(N1QLRelation.scala:77)
	at com.couchbase.spark.sql.N1QLRelation$$anonfun$3.apply(N1QLRelation.scala:58)
	at scala.Option.getOrElse(Option.scala:121)
	at com.couchbase.spark.sql.N1QLRelation.<init>(N1QLRelation.scala:58)
	at com.couchbase.spark.sql.DefaultSource.createRelation(DefaultSource.scala:54)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:340)
	at org.apache.spark.sql.DataFrameReader.loadV1Source(DataFrameReader.scala:239)
	at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:227)
	at org.apache.spark.sql.DataFrameReader.load(DataFrameReader.scala:164)
	at *****$.main(*****.scala:225)
	at *****.main(*****.scala)
```

~~Theoretically, this PR should solve this for us by allowing us to specify the timestamp format - however I am not yet able to verify since I can't seem to get the JAR file generated by your gradle file to work inside my existing sbt project (if there is some guidance around that as well, that'd be much appreciated!)~~

**please feel free to close and/or retarget as appropriate**